### PR TITLE
Add shorthand aliases for commands

### DIFF
--- a/src/application/commands/create/create-command.ts
+++ b/src/application/commands/create/create-command.ts
@@ -5,6 +5,7 @@ import CreateTemplateOperation from '@core/template/operations/create-template-o
 
 export default function buildCreateCommand() {
     return new Command('create')
+        .alias('new')
         .argument('<template-name>', 'unique template name')
         .argument('<source...>', 'source to save as template')
         .option('-f, --force', 'ignore warnings and errors', false)

--- a/src/application/commands/list/list-command.ts
+++ b/src/application/commands/list/list-command.ts
@@ -3,7 +3,7 @@ import container from '@infrastructure/container/di-container.ts';
 import ListTemplateOperation from '@core/template/operations/list-template-operation';
 
 export default function buildListCommand() {
-    return new Command('list').action(async () => {
+    return new Command('list').alias('ls').action(async () => {
         const operation = container.resolve<ListTemplateOperation>('ListTemplateOperation');
 
         await operation.execute();

--- a/src/application/commands/remove/remove-command.ts
+++ b/src/application/commands/remove/remove-command.ts
@@ -4,6 +4,7 @@ import RemoveTemplateOperation from '@core/template/operations/remove-template-o
 
 export default function buildRemoveCommand() {
     return new Command('remove')
+        .alias('rm')
         .argument('<template-name>', 'unique template identifier')
         .action(async (templateName: string) => {
             const operation = container.resolve<RemoveTemplateOperation>('RemoveTemplateOperation');


### PR DESCRIPTION
This PR adds shorthand aliases for commands to improve CLI usability.

**Changes:**
- `create`: alias `new`
- `remove`: alias `rm`
- `list`: alias `ls`

**Note:** The `get` command is intentionally left without an alias as it is designated to become the default base command in a future update (e.g., `tb <template-name>` will be an alias for `tb get <template-name>`).